### PR TITLE
Fix a lockup in libnf-info on aarch64 while parsing cmd line options.

### DIFF
--- a/src/libnf-info.c
+++ b/src/libnf-info.c
@@ -40,6 +40,7 @@ int main (int argc, char **argv) {
 	
 
 	while ((c = getopt (argc, argv, "i")) != -1) {
+		if (c == 255) break; // happens on aarch64
 		switch (c) {
 			case 'i': 	
 				ipfix_info = 1; 


### PR DESCRIPTION
While installing the Net::NfDump Perl module on a raspberry pi 4, it locked up while running libnf-info. It seems that getopt can return 255 instead of -1 in this platform? With the attach one liner the build process was successful.